### PR TITLE
スコアのロジック実装

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,8 +1,10 @@
 <script setup lang="ts">
 import CardItem from "@/components/CardItem.vue";
 import { useCards } from "@/stores/cards";
+import { useScores } from "@/stores/scores";
 
 const { cards, turnCard } = useCards();
+const { trialCount, pairedCount } = useScores();
 
 const onCardClick = (index: number) => {
   turnCard(index);
@@ -16,8 +18,8 @@ const onCardClick = (index: number) => {
     </div>
     <div class="score-container">
       <p class="score">
-        TRY: 000<br />
-        SCORE: 000
+        TRY: {{ trialCount }}<br />
+        SCORE: {{ pairedCount }}
       </p>
     </div>
   </header>

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,10 +1,12 @@
 <script setup lang="ts">
+import { storeToRefs } from "pinia";
 import CardItem from "@/components/CardItem.vue";
 import { useCards } from "@/stores/cards";
 import { useScores } from "@/stores/scores";
 
-const { cards, turnCard } = useCards();
-const { trialCount, pairedCount } = useScores();
+const { turnCard } = useCards();
+const { cards } = storeToRefs(useCards());
+const { trialCount, pairedCount } = storeToRefs(useScores());
 
 const onCardClick = (index: number) => {
   turnCard(index);

--- a/src/stores/cards.ts
+++ b/src/stores/cards.ts
@@ -1,5 +1,6 @@
 import { defineStore } from "pinia";
 import type { Card } from "@/types/card";
+import { useScores } from "@/stores/scores";
 
 const CARD_PAIR_SET = 10;
 
@@ -39,6 +40,7 @@ export const useCards = defineStore("card", {
       }
     },
     checkPair() {
+      const { getCorrect, getIncorrect } = useScores();
       const firstCard = this.cards[this.selectedIndexes[0]];
       const secondCard = this.cards[this.selectedIndexes[1]];
 
@@ -47,9 +49,11 @@ export const useCards = defineStore("card", {
         if (firstCard.number === secondCard.number) {
           firstCard.isPaired = true;
           secondCard.isPaired = true;
+          getCorrect();
         } else {
           firstCard.isTurned = false;
           secondCard.isTurned = false;
+          getIncorrect();
         }
         this.selectedIndexes = [];
       }, 1000);

--- a/src/stores/scores.ts
+++ b/src/stores/scores.ts
@@ -17,6 +17,15 @@ export const useScores = defineStore("score", {
     },
     pairedCount(state) {
       return get0paddingNumber(state._pairedCount);
-    }
-  }
+    },
+  },
+  actions: {
+    getCorrect() {
+      this._trialCount += 1;
+      this._pairedCount += 1;
+    },
+    getIncorrect() {
+      this._trialCount += 1;
+    },
+  },
 });

--- a/src/stores/scores.ts
+++ b/src/stores/scores.ts
@@ -1,0 +1,22 @@
+import { defineStore } from "pinia";
+
+const get0paddingNumber = (num: number): string => {
+  return ("00" + String(num)).slice(-3);
+};
+
+export const useScores = defineStore("score", {
+  state: () => {
+    return {
+      _trialCount: 0,
+      _pairedCount: 0,
+    };
+  },
+  getters: {
+    trialCount(state) {
+      return get0paddingNumber(state._trialCount);
+    },
+    pairedCount(state) {
+      return get0paddingNumber(state._pairedCount);
+    }
+  }
+});


### PR DESCRIPTION
- 試行回数と正解数を管理するスコアストアを作成
- カードを2枚めくったペアチェック時に、試行回数と正解数を反映