### PR TITLE
CSSの修正

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -21,7 +21,6 @@ import GameClear from '@/components/GameClear.vue'
 <style lang="css">
 .logo-container {
   background-color: black;
-  padding-bottom: 10px;
 }
 
 .logo {
@@ -29,6 +28,7 @@ import GameClear from '@/components/GameClear.vue'
   font-family: 'Monofett', cursive;
   font-size: 60px;
   margin: 0 auto;
+  padding: 20px 0 30px;
   width: var(--base-width);
 }
 

--- a/src/App.vue
+++ b/src/App.vue
@@ -19,10 +19,6 @@ import GameClear from '@/components/GameClear.vue'
 </template>
 
 <style lang="css">
-:root {
-  --base-width: 1135px;
-}
-
 .logo-container {
   background-color: black;
   padding-bottom: 10px;

--- a/src/assets/styles/main.css
+++ b/src/assets/styles/main.css
@@ -14,3 +14,7 @@ html {
   width: 100vw;
   height: 100vh;
 }
+
+:root {
+  --base-width: 1135px;
+}

--- a/src/assets/styles/main.css
+++ b/src/assets/styles/main.css
@@ -1,7 +1,7 @@
 @import './reset.css';
 
 html {
-  font-family: 'Avenir', Helvetica, Arial, sans-serif;
+  font-family: 'Press Start 2P', 'Avenir', Helvetica, Arial, sans-serif;
   -webkit-font-smoothing: antialiased;
   -moz-osx-font-smoothing: grayscale;
   color: #2c3e50;

--- a/src/components/GameClear.vue
+++ b/src/components/GameClear.vue
@@ -45,7 +45,6 @@ const reset = () => {
   border-radius: 5px;
   display: flex;
   flex-direction: column;
-  font-family: 'Press Start 2P', cursive;
   padding: 15px;
   text-align: center;
   width: 400px;

--- a/src/components/ScoreDisplay.vue
+++ b/src/components/ScoreDisplay.vue
@@ -23,7 +23,6 @@ const { trialCount, pairedCount } = storeToRefs(useScoreStore())
 
 .score {
   color: white;
-  font-family: 'Press Start 2P', cursive;
   line-height: 1.8;
   text-align: right;
   margin: 0 auto;


### PR DESCRIPTION
- デフォルトの文字を`Press Start 2p`に指定
- ロゴの余白を調整
- コンテンツ幅のCSS変数定義をmain.cssに移動